### PR TITLE
New feature: getOrElse

### DIFF
--- a/sandwich/src/main/java/com/skydoves/sandwich/ResponseTransformer.kt
+++ b/sandwich/src/main/java/com/skydoves/sandwich/ResponseTransformer.kt
@@ -89,6 +89,22 @@ internal inline fun <T> getCallbackFromOnResult(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns the encapsulated data if this instance represents [ApiResponse.Success] or
+ * returns the [defaultValue] if it is [ApiResponse.Failure.Error] or [ApiResponse.Failure.Exception].
+ *
+ * @return The encapsulated data or [defaultValue].
+ */
+fun <T> ApiResponse<T>.getOrElse(defaultValue: T): T? {
+  return when (this) {
+    is ApiResponse.Success -> data
+    is ApiResponse.Failure.Error -> defaultValue
+    is ApiResponse.Failure.Exception -> defaultValue
+  }
+}
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * Returns the encapsulated data if this instance represents [ApiResponse.Success] or
  * throws the encapsulated Throwable exception if it is [ApiResponse.Failure.Error] or [ApiResponse.Failure.Exception].
  *
  * @throws RuntimeException if it is [ApiResponse.Failure.Error] or

--- a/sandwich/src/test/java/com/skydoves/sandwich/ResponseTransformerTest.kt
+++ b/sandwich/src/test/java/com/skydoves/sandwich/ResponseTransformerTest.kt
@@ -49,6 +49,41 @@ class ResponseTransformerTest : ApiAbstract<DisneyService>() {
   }
 
   @Test
+  fun getOrElseOnSuccessTest() {
+    val response = Response.success("foo")
+    val apiResponse = ApiResponse.of { response }
+    val data = apiResponse.getOrElse("bar")
+
+    assertThat(data, `is`("foo"))
+  }
+
+  @Test
+  fun getOrElseOnErrorTest() {
+    val retrofit: Retrofit = Retrofit.Builder()
+      .baseUrl(mockWebServer.url("/"))
+      .addConverterFactory(GsonConverterFactory.create())
+      .build()
+
+    val service = retrofit.create(DisneyService::class.java)
+    mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody("foo"))
+
+    val responseBody = requireNotNull(service.fetchDisneyPosterList().execute().errorBody())
+    val apiResponse = ApiResponse.of { Response.error<Poster>(404, responseBody) }
+    val data = apiResponse.getOrElse("bar")
+
+    assertThat(data, `is`("bar"))
+  }
+
+  @Test
+  fun getOrElseOnExceptionTest() {
+    val exception = IllegalArgumentException("foo")
+    val apiResponse = ApiResponse.error<String>(exception)
+    val data = apiResponse.getOrElse("bar")
+
+    assertThat(data, `is`("bar"))
+  }
+
+  @Test
   fun getOrThrowOnSuccessTest() {
     val response = Response.success("foo")
     val apiResponse = ApiResponse.of { response }


### PR DESCRIPTION
## Overview
Returns the encapsulated data if this instance represents `ApiResponse.Success` or returns the `defaultValue` if it is `ApiResponse.Failure.Error` or `ApiResponse.Failure.Exception`.

```kotlin
interface DisneyService {

  @GET("DisneyPosters.json")
  suspend fun fetchPoster(): ApiResponse<Poster>
}

val data: Poster? = disneyService.fetchPoster().getOrElse(defaultValue = Poster(...))
```