### PR TITLE
Interface Update: data property of the `ApiResponse.Success` will be non-nullable

### DIFF
--- a/app/src/main/java/com/skydoves/sandwichdemo/coroutines/MainCoroutinesViewModel.kt
+++ b/app/src/main/java/com/skydoves/sandwichdemo/coroutines/MainCoroutinesViewModel.kt
@@ -50,7 +50,7 @@ class MainCoroutinesViewModel constructor(disneyService: DisneyCoroutinesService
               onSuccess = {
                 Timber.d("$data")
 
-                data?.let { emit(it) }
+                emit(data)
               },
               // handles error cases when the API request gets an error response.
               // e.g., internal server error.

--- a/app/src/main/java/com/skydoves/sandwichdemo/mapper/SuccessPosterMapper.kt
+++ b/app/src/main/java/com/skydoves/sandwichdemo/mapper/SuccessPosterMapper.kt
@@ -28,6 +28,6 @@ import com.skydoves.sandwichdemo.model.Poster
 object SuccessPosterMapper : ApiSuccessModelMapper<List<Poster>, Poster?> {
 
   override fun map(apiErrorResponse: ApiResponse.Success<List<Poster>>): Poster? {
-    return apiErrorResponse.data?.first()
+    return apiErrorResponse.data.first()
   }
 }

--- a/app/src/main/java/com/skydoves/sandwichdemo/operator/MainCoroutinesOperatorViewModel.kt
+++ b/app/src/main/java/com/skydoves/sandwichdemo/operator/MainCoroutinesOperatorViewModel.kt
@@ -40,7 +40,7 @@ class MainCoroutinesOperatorViewModel constructor(
       disneyService.fetchDisneyPosterList().suspendOperator(
         CommonResponseOperator(
           success = { success ->
-            success.data?.let { emit(it) }
+            emit(success.data)
             Timber.d("$success.data")
           },
           application = getApplication()

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$versions.gradleBuildTool"
@@ -32,7 +31,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,9 +19,9 @@ ext.versions = [
     versionName      : '1.0.9',
 
     gradleBuildTool  : '4.1.3',
-    spotlessGradle   : '5.12.3',
+    spotlessGradle   : '5.13.0',
     ktlintGradle     : '0.41.0',
-    dokkaGradle      : '1.4.30',
+    dokkaGradle      : '1.4.32',
     mavenPublish     : '0.15.1',
 
     kotlin           : '1.4.32',

--- a/sandwich/src/main/java/com/skydoves/sandwich/ApiResponse.kt
+++ b/sandwich/src/main/java/com/skydoves/sandwich/ApiResponse.kt
@@ -18,6 +18,7 @@
 
 package com.skydoves.sandwich
 
+import com.skydoves.sandwich.exceptions.NoContentException
 import com.skydoves.sandwich.operators.ApiResponseOperator
 import com.skydoves.sandwich.operators.ApiResponseSuspendOperator
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +52,7 @@ sealed class ApiResponse<out T> {
     val statusCode: StatusCode = getStatusCodeFromResponse(response)
     val headers: Headers = response.headers()
     val raw: okhttp3.Response = response.raw()
-    val data: T? = response.body()
+    val data: T = response.body() ?: throw NoContentException(statusCode.code)
     override fun toString() = "[ApiResponse.Success](data=$data)"
   }
 

--- a/sandwich/src/main/java/com/skydoves/sandwich/ResponseTransformer.kt
+++ b/sandwich/src/main/java/com/skydoves/sandwich/ResponseTransformer.kt
@@ -571,7 +571,7 @@ fun <T> ApiResponse<List<T>>.merge(
 
   for (response in apiResponses) {
     if (response is ApiResponse.Success) {
-      response.data?.let { data.addAll(it) }
+      data.addAll(response.data)
       apiResponse = ApiResponse.Success(
         Response.success(data, response.headers)
       )
@@ -666,7 +666,7 @@ inline fun <T, R> ApiResponse<T>.toLiveData(
 ): LiveData<R> {
   val liveData = MutableLiveData<R>()
   if (this is ApiResponse.Success) {
-    liveData.postValue(data?.transformer())
+    liveData.postValue(data.transformer())
   }
   return liveData
 }
@@ -687,7 +687,7 @@ suspend inline fun <T, R> ApiResponse<T>.toSuspendLiveData(
 ): LiveData<R> {
   val liveData = MutableLiveData<R>()
   if (this is ApiResponse.Success) {
-    liveData.postValue(data?.transformer())
+    liveData.postValue(data.transformer())
   }
   return liveData
 }
@@ -701,7 +701,7 @@ suspend inline fun <T, R> ApiResponse<T>.toSuspendLiveData(
  */
 @JvmSynthetic
 fun <T> ApiResponse<T>.toFlow(): Flow<T> {
-  return if (this is ApiResponse.Success && this.data != null) {
+  return if (this is ApiResponse.Success) {
     flowOf(data)
   } else {
     emptyFlow()
@@ -722,7 +722,7 @@ fun <T> ApiResponse<T>.toFlow(): Flow<T> {
 inline fun <T, R> ApiResponse<T>.toFlow(
   crossinline transformer: T.() -> R
 ): Flow<R> {
-  return if (this is ApiResponse.Success && this.data != null) {
+  return if (this is ApiResponse.Success) {
     flowOf(data.transformer())
   } else {
     emptyFlow()
@@ -744,7 +744,7 @@ inline fun <T, R> ApiResponse<T>.toFlow(
 suspend inline fun <T, R> ApiResponse<T>.toSuspendFlow(
   crossinline transformer: suspend T.() -> R
 ): Flow<R> {
-  return if (this is ApiResponse.Success && this.data != null) {
+  return if (this is ApiResponse.Success) {
     flowOf(data.transformer())
   } else {
     emptyFlow()

--- a/sandwich/src/main/java/com/skydoves/sandwich/exceptions/NoContentException.kt
+++ b/sandwich/src/main/java/com/skydoves/sandwich/exceptions/NoContentException.kt
@@ -1,0 +1,42 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.sandwich.exceptions
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * Thrown by various accessor methods to indicate that the response body being requested
+ * does not exist. e.g., 204 (NoContent), 205 (ResetContent).
+ *
+ * The server has successfully fulfilled the request with the 2xx code
+ * and that there is no additional content to send in the response payload body.
+ *
+ * If we want to handle empty body instead of throwing [NoContentException] for the 204 and 205 request case,
+ * use the [com.skydoves.sandwich.interceptor.EmptyBodyInterceptor] for your interceptor.
+ *
+ * ```
+ * OkHttpClient.Builder()
+ *   .addInterceptor(EmptyBodyInterceptor())
+ *   .build()
+ * ```
+ */
+class NoContentException constructor(
+  val code: Int,
+  override val message: String? =
+    "The server has successfully fulfilled the request with the code ($code) and that there is " +
+      "no additional content to send in the response payload body."
+) : Throwable(message)

--- a/sandwich/src/main/java/com/skydoves/sandwich/interceptor/EmptyBodyInterceptor.kt
+++ b/sandwich/src/main/java/com/skydoves/sandwich/interceptor/EmptyBodyInterceptor.kt
@@ -1,0 +1,56 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.sandwich.interceptor
+
+import com.skydoves.sandwich.StatusCode
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * Related: https://github.com/square/retrofit/issues/2867
+ *
+ * An interceptor for bypassing the [com.skydoves.sandwich.exceptions.NoContentException]
+ * when the server has successfully fulfilled the request with the 2xx code
+ * and that there is no additional content to send in the response payload body.
+ * e.g., 204 (NoContent), 205 (ResetContent).
+ */
+object EmptyBodyInterceptor : Interceptor {
+
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val response = chain.proceed(chain.request())
+    if (!response.isSuccessful || response.code.let {
+      it != StatusCode.NoContent.code && it != StatusCode.ResetContent.code
+    }
+    ) {
+      return response
+    }
+
+    if ((response.body?.contentLength()?.takeIf { it >= 0 } != null)) {
+      return response.newBuilder().code(200).build()
+    }
+
+    val emptyBody = "".toResponseBody("text/plain".toMediaType())
+
+    return response
+      .newBuilder()
+      .code(200)
+      .body(emptyBody)
+      .build()
+  }
+}

--- a/sandwich/src/test/java/com/skydoves/sandwich/ApiResponseTest.kt
+++ b/sandwich/src/test/java/com/skydoves/sandwich/ApiResponseTest.kt
@@ -95,7 +95,7 @@ class ApiResponseTest : ApiAbstract<DisneyService>() {
       assertThat(it, instanceOf(ApiResponse.Success::class.java))
       val response = requireNotNull((it as ApiResponse.Success))
       response.onSuccess {
-        val first = data?.firstOrNull()
+        val first = data.firstOrNull()
         assertThat(first?.id, `is`(0L))
         assertThat(first?.name, `is`("Frozen II"))
         assertThat(first?.release, `is`("2019"))

--- a/sandwich/src/test/java/com/skydoves/sandwich/SuccessPosterMapper.kt
+++ b/sandwich/src/test/java/com/skydoves/sandwich/SuccessPosterMapper.kt
@@ -19,6 +19,6 @@ package com.skydoves.sandwich
 object SuccessPosterMapper : ApiSuccessModelMapper<List<Poster>, Poster?> {
 
   override fun map(apiErrorResponse: ApiResponse.Success<List<Poster>>): Poster? {
-    return apiErrorResponse.data?.first()
+    return apiErrorResponse.data.first()
   }
 }


### PR DESCRIPTION
## Guidelines
[Discussing thread](https://github.com/skydoves/Sandwich/issues/20).

#### The data property will be non-nullable type

Previously, The data property in the `ApiResponse.Success` will be null if the response has been succeeded but there is not body data regardless of the status code. But in the next version, the response body could not be nullable for the 204, 205 response code. Instead, throwing `NoContentException` if we access the empty body.

#### NoContentException
If we want to bypass the `NoContentException` and handle it as an empty body, we can use the `EmptyBodyInterceptor`.

```kotlin
 OkHttpClient.Builder()
   .addInterceptor(EmptyBodyInterceptor())
   .build()
 ```

[Alternative solution](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/common/src/flow/operators/Errors.kt) for catching the exception continuously for the `ApiResponse` scopes.

```kotlin
response.onSuccess {

}.onError {

}.onException {
  // exception will be delegated on here.
}
```