### PR TITLE
Bump Kotlin to 1.6.21 and Coroutines 1.6.1

### DIFF
--- a/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
 
   internal const val RETROFIT = "2.9.0"
   internal const val OKHTTP = "4.9.3"
-  internal const val COROUTINES = "1.6.0"
+  internal const val COROUTINES = "1.6.1"
   internal const val MOSHI = "1.13.0"
 
   internal const val APPCOMPAT = "1.4.1"

--- a/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
@@ -4,7 +4,7 @@ object Versions {
   internal const val ANDROID_GRADLE_PLUGIN = "7.1.2"
   internal const val ANDROID_GRADLE_SPOTLESS = "6.3.0"
   internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-  internal const val KOTLIN = "1.5.32"
+  internal const val KOTLIN = "1.6.21"
   internal const val KOTLIN_GRADLE_DOKKA = "1.6.10"
   internal const val KOTLIN_BINARY_VALIDATOR = "0.8.0"
 
@@ -16,7 +16,6 @@ object Versions {
   internal const val APPCOMPAT = "1.4.1"
   internal const val MATERIAL = "1.5.0"
   internal const val GLIDE = "4.13.1"
-  internal const val BASE_ADAPTER = "1.0.4"
   internal const val LIFECYCLE = "2.4.1"
   internal const val TIMBER = "5.0.1"
 


### PR DESCRIPTION
## Overview
Bump Kotlin to 1.6.21 and Coroutines 1.6.1.