### PR TITLE
Support Deferred for ApiResponseCallAdapterFactory

### DIFF
--- a/app/src/main/kotlin/com/skydoves/sandwichdemo/MainRepository.kt
+++ b/app/src/main/kotlin/com/skydoves/sandwichdemo/MainRepository.kt
@@ -22,5 +22,5 @@ class MainRepository constructor(
   private val disneyService: DisneyService
 ) {
 
-  suspend fun fetchPosters() = disneyService.fetchDisneyPosterList()
+  suspend fun fetchPosters() = disneyService.fetchDisneyPosters()
 }

--- a/app/src/main/kotlin/com/skydoves/sandwichdemo/network/DisneyService.kt
+++ b/app/src/main/kotlin/com/skydoves/sandwichdemo/network/DisneyService.kt
@@ -18,10 +18,14 @@ package com.skydoves.sandwichdemo.network
 
 import com.skydoves.sandwich.ApiResponse
 import com.skydoves.sandwichdemo.model.Poster
+import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 
 interface DisneyService {
 
   @GET("DisneyPosters.json")
-  suspend fun fetchDisneyPosterList(): ApiResponse<List<Poster>>
+  suspend fun fetchDisneyPosters(): ApiResponse<List<Poster>>
+
+  @GET("DisneyPosters.json")
+  fun fetchDisneyPostersAsync(): Deferred<ApiResponse<List<Poster>>>
 }

--- a/app/src/main/kotlin/com/skydoves/sandwichdemo/operator/MainOperatorViewModel.kt
+++ b/app/src/main/kotlin/com/skydoves/sandwichdemo/operator/MainOperatorViewModel.kt
@@ -37,7 +37,7 @@ class MainOperatorViewModel constructor(
     Timber.d("initialized MainViewModel.")
 
     posterListLiveData = liveData(viewModelScope.coroutineContext + Dispatchers.IO) {
-      disneyService.fetchDisneyPosterList().suspendOperator(
+      disneyService.fetchDisneyPosters().suspendOperator(
         CommonResponseOperator(
           success = { success ->
             emit(success.data)

--- a/build.gradle
+++ b/build.gradle
@@ -18,19 +18,19 @@ apply plugin: 'io.github.gradle-nexus.publish-plugin'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-      maven { url "https://plugins.gradle.org/m2/" }
-    }
-    dependencies {
-      classpath Dependencies.androidGradlePlugin
-      classpath Dependencies.kotlinGradlePlugin
-      classpath Dependencies.spotlessGradlePlugin
-      classpath Dependencies.gradleNexusPublishPlugin
-      classpath Dependencies.dokka
-      classpath Dependencies.kotlinBinaryValidator
-    }
+  repositories {
+    google()
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
+  }
+  dependencies {
+    classpath Dependencies.androidGradlePlugin
+    classpath Dependencies.kotlinGradlePlugin
+    classpath Dependencies.spotlessGradlePlugin
+    classpath Dependencies.gradleNexusPublishPlugin
+    classpath Dependencies.dokka
+    classpath Dependencies.kotlinBinaryValidator
+  }
 }
 
 task clean(type: Delete) {

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/ApiResponseCallAdapterFactory.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/ApiResponseCallAdapterFactory.kt
@@ -19,6 +19,9 @@
 package com.skydoves.sandwich.adapters
 
 import com.skydoves.sandwich.ApiResponse
+import com.skydoves.sandwich.adapters.internal.ApiResponseCallAdapter
+import com.skydoves.sandwich.adapters.internal.ApiResponseDeferredCallAdapter
+import kotlinx.coroutines.Deferred
 import retrofit2.Call
 import retrofit2.CallAdapter
 import retrofit2.Retrofit
@@ -54,6 +57,16 @@ public class ApiResponseCallAdapterFactory private constructor() : CallAdapter.F
 
         val resultType = getParameterUpperBound(0, callType as ParameterizedType)
         return ApiResponseCallAdapter(resultType)
+      }
+      Deferred::class.java -> {
+        val callType = getParameterUpperBound(0, returnType as ParameterizedType)
+        val rawType = getRawType(callType)
+        if (rawType != ApiResponse::class.java) {
+          return null
+        }
+
+        val resultType = getParameterUpperBound(0, callType as ParameterizedType)
+        return ApiResponseDeferredCallAdapter<Any>(resultType)
       }
       else -> return null
     }

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/DataSourceCallAdapterFactory.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/DataSourceCallAdapterFactory.kt
@@ -17,6 +17,8 @@
 package com.skydoves.sandwich.adapters
 
 import com.skydoves.sandwich.DataSource
+import com.skydoves.sandwich.adapters.internal.DataSourceCallAdapter
+import com.skydoves.sandwich.adapters.internal.DataSourceRawCallAdapter
 import retrofit2.Call
 import retrofit2.CallAdapter
 import retrofit2.Retrofit

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/internal/ApiResponseCallAdapter.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/internal/ApiResponseCallAdapter.kt
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.skydoves.sandwich.adapters
+package com.skydoves.sandwich.adapters.internal
 
-import com.skydoves.sandwich.DataSource
-import com.skydoves.sandwich.ResponseDataSource
+import com.skydoves.sandwich.ApiResponse
 import retrofit2.Call
 import retrofit2.CallAdapter
 import java.lang.reflect.Type
@@ -25,20 +24,19 @@ import java.lang.reflect.Type
 /**
  * @author skydoves (Jaewoong Eum)
  *
- * DataSourceCallAdapter is an call adapter for creating [DataSource] from service method.
+ * ApiResponseCallAdapter is an call adapter for creating [ApiResponse] by executing Retrofit's service methods.
  *
- * request API network call asynchronously and returns [DataSource].
+ * Request API network call asynchronously and returns [ApiResponse].
  */
-internal class DataSourceRawCallAdapter<R> constructor(
-  private val responseType: Type
-) : CallAdapter<R, DataSource<R>> {
+internal class ApiResponseCallAdapter constructor(
+  private val resultType: Type
+) : CallAdapter<Type, Call<ApiResponse<Type>>> {
 
   override fun responseType(): Type {
-    return responseType
+    return resultType
   }
 
-  override fun adapt(call: Call<R>): DataSource<R> {
-    val responseDataSource: ResponseDataSource<R> = ResponseDataSource()
-    return responseDataSource.combine(call, null)
+  override fun adapt(call: Call<Type>): Call<ApiResponse<Type>> {
+    return ApiResponseCallDelegate(call)
   }
 }

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/internal/DataSourceCallAdapter.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/internal/DataSourceCallAdapter.kt
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.skydoves.sandwich.adapters
+package com.skydoves.sandwich.adapters.internal
 
 import com.skydoves.sandwich.DataSource
-import com.skydoves.sandwich.adapters.internal.DataSourceCallDelegate
 import retrofit2.Call
 import retrofit2.CallAdapter
 import java.lang.reflect.Type

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/internal/DataSourceRawCallAdapter.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/internal/DataSourceRawCallAdapter.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.skydoves.sandwich.adapters
+package com.skydoves.sandwich.adapters.internal
 
-import com.skydoves.sandwich.ApiResponse
-import com.skydoves.sandwich.adapters.internal.ApiResponseCallDelegate
+import com.skydoves.sandwich.DataSource
+import com.skydoves.sandwich.ResponseDataSource
 import retrofit2.Call
 import retrofit2.CallAdapter
 import java.lang.reflect.Type
@@ -25,19 +25,20 @@ import java.lang.reflect.Type
 /**
  * @author skydoves (Jaewoong Eum)
  *
- * CoroutinesResponseCallAdapter is an coroutines call adapter for creating [ApiResponse] from service method.
+ * DataSourceCallAdapter is an call adapter for creating [DataSource] from service method.
  *
- * request API network call asynchronously and returns [ApiResponse].
+ * request API network call asynchronously and returns [DataSource].
  */
-internal class ApiResponseCallAdapter constructor(
-  private val resultType: Type
-) : CallAdapter<Type, Call<ApiResponse<Type>>> {
+internal class DataSourceRawCallAdapter<R> constructor(
+  private val responseType: Type
+) : CallAdapter<R, DataSource<R>> {
 
   override fun responseType(): Type {
-    return resultType
+    return responseType
   }
 
-  override fun adapt(call: Call<Type>): Call<ApiResponse<Type>> {
-    return ApiResponseCallDelegate(call)
+  override fun adapt(call: Call<R>): DataSource<R> {
+    val responseDataSource: ResponseDataSource<R> = ResponseDataSource()
+    return responseDataSource.combine(call, null)
   }
 }

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/coroutines/CoroutinesDataSourceCallAdapter.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/coroutines/CoroutinesDataSourceCallAdapter.kt
@@ -31,7 +31,7 @@ import java.lang.reflect.Type
  */
 @Deprecated(
   message = "CoroutinesDataSourceCallAdapter has been deprecated. Use `DataSourceCallAdapter` instead.",
-  replaceWith = ReplaceWith("com.skydoves.sandwich.adapters.DataSourceCallAdapter"),
+  replaceWith = ReplaceWith("com.skydoves.sandwich.adapters.internal.DataSourceCallAdapter"),
   level = DeprecationLevel.WARNING
 )
 internal class CoroutinesDataSourceCallAdapter constructor(

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/coroutines/CoroutinesResponseCallAdapter.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/coroutines/CoroutinesResponseCallAdapter.kt
@@ -31,7 +31,7 @@ import java.lang.reflect.Type
  */
 @Deprecated(
   message = "CoroutinesResponseCallAdapter has been deprecated. Use `ApiResponseCallAdapter` instead.",
-  replaceWith = ReplaceWith("com.skydoves.sandwich.adapters.ApiResponseCallAdapter"),
+  replaceWith = ReplaceWith("com.skydoves.sandwich.adapters.internal.ApiResponseCallAdapter"),
   level = DeprecationLevel.WARNING
 )
 internal class CoroutinesResponseCallAdapter constructor(


### PR DESCRIPTION
## Overview
Support Deferred for ApiResponseCallAdapterFactory as the below:

```kotlin
interface DisneyService {

  @GET("DisneyPosters.json")
  fun fetchDisneyPostersAsync(): Deferred<ApiResponse<List<Poster>>>
}


class MainRepository constructor(
  private val disneyService: DisneyService
) {

  suspend fun fetchPosters() = disneyService.fetchDisneyPostersAsync().await()
}
```