### PR TITLE
Bump AGP to 7.2.1 and spotless, binary validator plugin versions

### DIFF
--- a/app/src/main/kotlin/com/skydoves/sandwichdemo/operator/MainOperatorActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/sandwichdemo/operator/MainOperatorActivity.kt
@@ -34,7 +34,8 @@ class MainOperatorActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     DataBindingUtil.setContentView<ActivityMainCoroutinesOperatorBinding>(
-      this, R.layout.activity_main_coroutines_operator
+      this,
+      R.layout.activity_main_coroutines_operator
     ).apply {
       lifecycleOwner = this@MainOperatorActivity
       viewModel = this@MainOperatorActivity.viewModel

--- a/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
@@ -1,17 +1,17 @@
 package com.github.skydoves.sandwich
 
 object Versions {
-  internal const val ANDROID_GRADLE_PLUGIN = "7.2.0"
-  internal const val ANDROID_GRADLE_SPOTLESS = "6.3.0"
+  internal const val ANDROID_GRADLE_PLUGIN = "7.2.1"
+  internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
   internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
   internal const val KOTLIN = "1.7.10"
   internal const val KOTLIN_SERIALIZATION_JSON = "1.3.2"
-  internal const val KOTLIN_GRADLE_DOKKA = "1.7.0"
-  internal const val KOTLIN_BINARY_VALIDATOR = "0.10.1"
+  internal const val KOTLIN_GRADLE_DOKKA = "1.7.10"
+  internal const val KOTLIN_BINARY_VALIDATOR = "0.11.0"
 
   internal const val RETROFIT = "2.9.0"
   internal const val OKHTTP = "4.9.3"
-  internal const val COROUTINES = "1.6.1"
+  internal const val COROUTINES = "1.6.4"
   internal const val MOSHI = "1.13.0"
 
   internal const val APPCOMPAT = "1.4.1"

--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/ApiResponseCallAdapterFactory.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/adapters/ApiResponseCallAdapterFactory.kt
@@ -49,7 +49,7 @@ public class ApiResponseCallAdapterFactory private constructor(
   override fun get(
     returnType: Type,
     annotations: Array<Annotation>,
-    retrofit: Retrofit,
+    retrofit: Retrofit
   ): CallAdapter<*, *>? {
     when (getRawType(returnType)) {
       Call::class.java -> {

--- a/sandwich/src/test/kotlin/com/skydoves/sandwich/ResponseRetryTest.kt
+++ b/sandwich/src/test/kotlin/com/skydoves/sandwich/ResponseRetryTest.kt
@@ -41,7 +41,7 @@ internal class ResponseRetryTest : ApiAbstract<DisneyCoroutinesService>() {
     var retryTick = 0
     val response = retry(
       retry = 2,
-      timeMillis = 0,
+      timeMillis = 0
     ) {
       retryTick++
       mockWebServer.enqueue(MockResponse().setResponseCode(404).setBody("foo"))

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -17,7 +17,8 @@ apply plugin: "com.diffplug.spotless"
 spotless {
   kotlin {
     target "**/*.kt"
-    ktlint().userData(['indent_size': '2', 'continuation_indent_size': '2'])
+    targetExclude "**/build/**/*.kt"
+    ktlint().setUseExperimental(true).editorConfigOverride(['indent_size': '2', 'continuation_indent_size': '2'])
     licenseHeaderFile "$rootDir/spotless.license.kt"
     trimTrailingWhitespace()
     endWithNewline()


### PR DESCRIPTION
## Guidelines
Bump AGP to 7.2.1 and spotless, binary validator plugin versions.