### PR TITLE
Update AGP to 7.3.0 and Kotlin to 1.7.20

### DIFF
--- a/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Dependencies.kt
@@ -1,13 +1,13 @@
 package com.github.skydoves.sandwich
 
 object Versions {
-  internal const val ANDROID_GRADLE_PLUGIN = "7.2.1"
+  internal const val ANDROID_GRADLE_PLUGIN = "7.3.0"
   internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
   internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-  internal const val KOTLIN = "1.7.10"
+  internal const val KOTLIN = "1.7.20"
   internal const val KOTLIN_SERIALIZATION_JSON = "1.4.0"
   internal const val KOTLIN_GRADLE_DOKKA = "1.7.10"
-  internal const val KOTLIN_BINARY_VALIDATOR = "0.11.0"
+  internal const val KOTLIN_BINARY_VALIDATOR = "0.11.1"
 
   internal const val RETROFIT = "2.9.0"
   internal const val OKHTTP = "4.10.0"


### PR DESCRIPTION
## Guidelines
Update AGP to `7.3.0` and Kotlin to `1.7.20`.