### PR TITLE
Fix wrong parameter name of ApiSuccessModelMapper

### DIFF
--- a/sandwich/src/main/kotlin/com/skydoves/sandwich/ApiSuccessModelMapper.kt
+++ b/sandwich/src/main/kotlin/com/skydoves/sandwich/ApiSuccessModelMapper.kt
@@ -21,15 +21,15 @@ package com.skydoves.sandwich
  *
  * A mapper interface for mapping [ApiResponse.Success] response as a custom [V] instance model.
  *
- * @see [ApiSuccessModelMapper](https://github.com/skydoves/sandwich#apierrormodelmapper)
+ * @see [ApiSuccessModelMapper](https://github.com/skydoves/sandwich#apisuccessmodelmapper)
  */
 public fun interface ApiSuccessModelMapper<T, V> {
 
   /**
    * maps the [ApiResponse.Success] to the [V] using the mapper.
    *
-   * @param apiErrorResponse The [ApiResponse.Success] error response from the network request.
+   * @param apiSuccessResponse The [ApiResponse.Success] response from the network request.
    * @return A custom [V] success response model.
    */
-  public fun map(apiErrorResponse: ApiResponse.Success<T>): V
+  public fun map(apiSuccessResponse: ApiResponse.Success<T>): V
 }


### PR DESCRIPTION
### 🎯 Goal
Fix wrong parameter name of ApiSuccessModelMapper. (#77)