### PR TITLE
fix: mapper.md typo

### DIFF
--- a/docs/mapper.md
+++ b/docs/mapper.md
@@ -50,8 +50,8 @@ You can map the `ApiResponse.Success` model to your custom model using the `Succ
 ```kotlin
 object SuccessPosterMapper : ApiSuccessModelMapper<List<Poster>, Poster?> {
 
-  override fun map(apiErrorResponse: ApiResponse.Success<List<Poster>>): Poster? {
-    return apiErrorResponse.data.first()
+  override fun map(apiSuccessResponse: ApiResponse.Success<List<Poster>>): Poster? {
+    return apiSuccessResponse.data.first()
   }
 }
 


### PR DESCRIPTION
안녕하세요 재웅님 라이브러리 잘 활용하고 있습니다!
사용하다가 문서에 조금의 오탈자를 발견하여 PR 올립니다!
mapper.md) apiErrorResponse -> apiSuccessResponse on SuccessPosterMapper 

Hello skydoves, I am using the library well!
While using it, I found a few typos in the document and am uploading a PR.
mapper.md) apiErrorResponse -> apiSuccessResponse on SuccessPosterMapper 

### 🎯 Goal
Fix typo

### 🛠 Implementation details
mapper.md) apiErrorResponse -> apiSuccessResponse on SuccessPosterMapper 

### ✍️ Explain examples
NA

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

Then dump binary APIs of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

```bash
./gradlew apiDump
```

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
