### PR TITLE
Fix the global operator and mapper doesn't applied for the exception factory

### DIFF
--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ApiResponse.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ApiResponse.kt
@@ -108,7 +108,7 @@ public sealed interface ApiResponse<out T> {
      * @return A [ApiResponse.Failure.Exception] based on the throwable.
      */
     public fun exception(ex: Throwable): Failure.Exception =
-      Failure.Exception(ex).apply { operate().maps() }
+      Failure.Exception(ex).operate().maps() as Failure.Exception
 
     /**
      * @author skydoves (Jaewoong Eum)


### PR DESCRIPTION
Fix the global operator and mapper doesn't applied for the exception factory. (#292)