### PR TITLE
Using response in Error for ktorfit converter

### DIFF
--- a/sandwich-ktorfit/src/commonMain/kotlin/com/skydoves/sandwich/ktorfit/ApiResponseConverterFactory.kt
+++ b/sandwich-ktorfit/src/commonMain/kotlin/com/skydoves/sandwich/ktorfit/ApiResponseConverterFactory.kt
@@ -56,7 +56,7 @@ public class ApiResponseConverterFactory internal constructor() : Converter.Fact
                 if (result.response.getStatusCode().code in SandwichInitializer.successCodeRange) {
                   ApiResponse.Success(result.response.body(typeData.typeArgs.first().typeInfo))
                 } else {
-                  ApiResponse.Failure.Error(result.response.bodyAsText())
+                  ApiResponse.Failure.Error(result.response)
                 }
               }
 


### PR DESCRIPTION
### 🎯 Goal
As described in https://github.com/skydoves/sandwich/issues/431, the payload for an api error is set to the body text resulting in not being able to retrieve the http status of the error.

### 🛠 Implementation details
Changing the payload to be the whole response as expected

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
