### PR TITLE
Remove redundant casting for the failure check inside the map

### DIFF
--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ApiResponse.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ApiResponse.kt
@@ -182,7 +182,7 @@ public sealed interface ApiResponse<out T> {
       mappers.forEach { mapper ->
         if (response is Failure) {
           if (mapper is ApiResponseFailureMapper) {
-            response = mapper.map(response as Failure<T>) as ApiResponse<T>
+            response = mapper.map(response) as ApiResponse<T>
           } else if (mapper is ApiResponseFailureSuspendMapper) {
             val scope = SandwichInitializer.sandwichScope
             scope.launch {


### PR DESCRIPTION
Remove redundant casting for the failure check inside the map.