### PR TITLE
Prepare for release 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Add the dependency below into your **module**'s `build.gradle` file:
 
 ```gradle
 dependencies {
-    implementation("com.github.skydoves:sandwich:2.2.2")
-    implementation("com.github.skydoves:sandwich-retrofit:2.2.2") // For Retrofit (Android)
-    testImplementation("com.github.skydoves:sandwich-test:2.2.2") // For Testing
+    implementation("com.github.skydoves:sandwich:2.3.0")
+    implementation("com.github.skydoves:sandwich-retrofit:2.3.0") // For Retrofit (Android)
+    testImplementation("com.github.skydoves:sandwich-test:2.3.0") // For Testing
 }
 ```
 

--- a/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Configuration.kt
@@ -22,10 +22,10 @@ object Configuration {
   const val minSdk = 21
   const val minSdkDemo = 21
   const val majorVersion = 2
-  const val minorVersion = 2
-  const val patchVersion = 2
+  const val minorVersion = 3
+  const val patchVersion = 0
   const val versionName = "$majorVersion.$minorVersion.$patchVersion"
-  const val versionCode = 49
+  const val versionCode = 50
   const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
   const val artifactGroup = "com.github.skydoves"
 }


### PR DESCRIPTION
## Prepare for release 2.3.0

Bumps the library version `2.2.2` → `2.3.0` ahead of the Maven Central release.

### Changes
- `Configuration.kt`: `minorVersion` 2 → 3, `patchVersion` 2 → 0, `versionCode` 49 → 50 (`versionName` now `2.3.0`)
- `README.md`: install snippet versions updated to `2.3.0`

This release is cut from `main`, which already includes the Kotlin 2.4.0 toolchain/dependency updates (#630).

### Verification
- `buildSrc` compiles cleanly with the new version constants
- No remaining `2.2.2` references in the repo
