### PR TITLE
Add envelope support and fix global pipeline re-entrancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ google-services.json
 freeline.py
 freeline/
 freeline_project_description.json
+
+# Local working notes (plans, lessons)
+tasks/

--- a/docs/envelope.md
+++ b/docs/envelope.md
@@ -1,0 +1,143 @@
+# Envelope
+
+Many backends answer with HTTP 200 regardless of the business outcome, and encode the real result
+inside the body:
+
+```json
+{ "code": 0, "message": "ok", "data": { ... } }
+```
+
+Sandwich classifies such a response as `ApiResponse.Success`, because the transport layer did
+succeed. The **envelope** support lets Sandwich additionally understand the *business* outcome, so
+a business failure is classified as `ApiResponse.Failure.Error` and the payload can be flattened.
+
+## ApiEnvelope
+
+Implement `ApiEnvelope<T, E>` on the response model, where `T` is the business payload and `E` is
+the business error:
+
+```kotlin
+data class BaseResponse<T>(
+  val code: Int,
+  val message: String,
+  val data: T?,
+) : ApiEnvelope<T?, String> {
+  override val isEnvelopeSuccessful: Boolean get() = code == 0
+  override val envelopeBody: T? get() = data
+  override val envelopeError: String get() = message
+}
+```
+
+`envelopeBody` is only read when `isEnvelopeSuccessful` is `true`, and `envelopeError` only when it
+is `false`, so the unused side may throw or return a placeholder.
+
+## Automatic classification
+
+`ApiEnvelopeMapper` is registered on `SandwichInitializer.sandwichSuccessMappers` **by default**, so
+a business failure is demoted to `ApiResponse.Failure.Error` without any setup:
+
+```kotlin
+val response = service.fetchPosters() // ApiResponse<BaseResponse<List<Poster>>>
+
+response.onSuccess {
+  // only runs when code == 0
+}.onError {
+  // runs when code != 0, and `payload` is the envelope's message
+}
+```
+
+This also means global operators and global failure mappers observe the business failure, so
+cross-cutting concerns such as logging or token refresh see a consistent picture.
+
+A response body that does not implement `ApiEnvelope` passes through untouched, so the default
+registration has no effect on models that do not opt in. To opt out entirely:
+
+```kotlin
+SandwichInitializer.sandwichSuccessMappers -= ApiEnvelopeMapper
+```
+
+## unwrap
+
+Automatic classification does not change the *type* of the response, because the runtime payload
+must keep agreeing with the declared type. Use `unwrap` to flatten
+`ApiResponse<BaseResponse<T>>` into `ApiResponse<T>`, typically at the repository boundary:
+
+```kotlin
+// service declares the wire type
+interface PosterService {
+  @GET("posters")
+  suspend fun fetchPosters(): ApiResponse<BaseResponse<List<Poster>>>
+}
+
+// repository exposes the business type
+class PosterRepository(private val service: PosterService) {
+  suspend fun posters(): ApiResponse<List<Poster>?> = service.fetchPosters().unwrap()
+}
+```
+
+`unwrap` handles all three cases:
+
+| Input | Output |
+|---|---|
+| `Success` with a business-successful envelope | `Success` holding `envelopeBody` |
+| `Success` with a business-failed envelope | `Failure.Error` holding `envelopeError` |
+| `Failure.Error` / `Failure.Exception` | returned as is |
+
+The `tag` of a successful response is preserved, so Retrofit and Ktor extensions such as
+`statusCode` and `headers` keep working after unwrapping.
+
+## ApiEnvelopeSpec
+
+When the response model cannot be modified — a generated DTO, or a model owned by another module —
+describe the envelope contract from the outside with `ApiEnvelopeSpec`:
+
+```kotlin
+data class LegacyResponse(val status: String, val payload: String, val reason: String)
+
+object LegacyResponseSpec : ApiEnvelopeSpec<LegacyResponse, String, String> {
+  override fun isEnvelopeSuccessful(envelope: LegacyResponse) = envelope.status == "OK"
+  override fun envelopeBody(envelope: LegacyResponse) = envelope.payload
+  override fun envelopeError(envelope: LegacyResponse) = envelope.reason
+}
+
+val response: ApiResponse<String> = service.fetchLegacy().unwrap(LegacyResponseSpec)
+```
+
+Note that a spec is only consulted by an explicit `unwrap(spec)` call. Automatic classification
+relies on the `ApiEnvelope` interface, because it has to recognize the envelope at runtime.
+
+## Non-JSON error bodies
+
+`ApiEnvelope` is not limited to a `code`/`message`/`data` shape. Any rule that inspects the parsed
+body works, which covers servers that answer HTTP 200 with an error page:
+
+```kotlin
+data class SpreadSheetResponse(val raw: String) : ApiEnvelope<String, String> {
+  override val isEnvelopeSuccessful: Boolean get() = !raw.startsWith("<!DOCTYPE html")
+  override val envelopeBody: String get() = raw
+  override val envelopeError: String get() = "the server returned an HTML error page"
+}
+```
+
+## Custom success mappers
+
+`ApiEnvelopeMapper` is a regular `ApiResponseSuccessMapper`, and you can register your own to run
+any global rule that may demote a success:
+
+```kotlin
+SandwichInitializer.sandwichSuccessMappers += ApiResponseSuccessMapper { response ->
+  val data = response.data
+  if (data is List<*> && data.isEmpty()) {
+    ApiResponse.Failure.Error(payload = "empty result")
+  } else {
+    response
+  }
+}
+```
+
+Success mappers run **before** failure mappers, so a demoted response still flows through
+[global failure mappers](mapper.md#global-failure-mapper).
+
+For a suspending rule, implement `ApiResponseSuccessSuspendMapper` instead. It is only applied on
+suspending creation paths such as `ApiResponse.suspendOf`, because a suspending mapper cannot be
+awaited from a blocking one.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - 'Ktorfit': ktorfit.md
   - 'Retrieve': retrieve.md
   - 'Mapper': mapper.md
+  - 'Envelope': envelope.md
   - 'Sequential': sequential.md
   - 'Retry': retry.md
   - 'Operator': operator.md

--- a/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/ApiEnvelopeTest.kt
+++ b/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/ApiEnvelopeTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich
+
+import com.skydoves.sandwich.envelope.ApiEnvelope
+import com.skydoves.sandwich.envelope.ApiEnvelopeMapper
+import com.skydoves.sandwich.envelope.ApiEnvelopeSpec
+import com.skydoves.sandwich.envelope.unwrap
+import com.skydoves.sandwich.mappers.ApiResponseFailureMapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.Is.`is`
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Verifies the envelope (`BaseResponse`) design spike against the scenarios reported in
+ * issues #30, #38, #85, and #138.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+internal class ApiEnvelopeTest {
+
+  /** `{ "code": 0, "msg": "success", "data": { ... } }` — issues #30, #38, #138. */
+  private data class BaseResponse<T>(val code: Int, val msg: String, val data: T?) :
+    ApiEnvelope<T?, String> {
+    override val isEnvelopeSuccessful: Boolean get() = code == 0
+    override val envelopeBody: T? get() = data
+    override val envelopeError: String get() = msg
+  }
+
+  /** A model that cannot be modified, described from the outside — the non-intrusive path. */
+  private data class LegacyResponse(val status: String, val payload: String, val reason: String)
+
+  private object LegacyResponseSpec : ApiEnvelopeSpec<LegacyResponse, String, String> {
+    override fun isEnvelopeSuccessful(envelope: LegacyResponse) = envelope.status == "OK"
+    override fun envelopeBody(envelope: LegacyResponse) = envelope.payload
+    override fun envelopeError(envelope: LegacyResponse) = envelope.reason
+  }
+
+  /** Issue #85 — Google Apps Script answers HTTP 200 with an HTML error page. */
+  private data class SpreadSheetResponse(val raw: String) : ApiEnvelope<String, String> {
+    override val isEnvelopeSuccessful: Boolean get() = !raw.startsWith("<!DOCTYPE html")
+    override val envelopeBody: String get() = raw
+    override val envelopeError: String get() = "Apps Script returned an HTML error page"
+  }
+
+  @After
+  fun tearDown() {
+    // NOTE: global state leaks between tests today — this is finding C3
+    // (sandwich-test needs a reset rule).
+    SandwichInitializer.sandwichSuccessMappers = mutableListOf()
+    SandwichInitializer.sandwichFailureMappers = mutableListOf()
+  }
+
+  @Test
+  fun `unwrap flattens a business-successful envelope into the payload`() {
+    val response: ApiResponse<BaseResponse<String>> =
+      ApiResponse.Success(BaseResponse(code = 0, msg = "success", data = "poster"))
+
+    val unwrapped: ApiResponse<String?> = response.unwrap()
+
+    assertThat(unwrapped is ApiResponse.Success, `is`(true))
+    assertThat(unwrapped.getOrNull(), `is`("poster"))
+  }
+
+  @Test
+  fun `unwrap demotes a business-failed envelope to Failure Error`() {
+    val response: ApiResponse<BaseResponse<String>> =
+      ApiResponse.Success(BaseResponse(code = -1, msg = "fail", data = null))
+
+    val unwrapped: ApiResponse<String?> = response.unwrap()
+
+    assertThat(unwrapped is ApiResponse.Failure.Error, `is`(true))
+    assertThat((unwrapped as ApiResponse.Failure.Error).payload, `is`("fail"))
+  }
+
+  @Test
+  fun `unwrap preserves the tag of a successful envelope`() {
+    val response: ApiResponse<BaseResponse<String>> =
+      ApiResponse.Success(BaseResponse(0, "success", "poster"), tag = "myTag")
+
+    assertThat(response.unwrap().tagOrNull(), `is`("myTag"))
+  }
+
+  @Test
+  fun `unwrap passes an existing transport failure through untouched`() {
+    val throwable = RuntimeException("no network")
+    val response: ApiResponse<BaseResponse<String>> = ApiResponse.Failure.Exception(throwable)
+
+    val unwrapped: ApiResponse<String?> = response.unwrap()
+
+    assertThat(unwrapped is ApiResponse.Failure.Exception, `is`(true))
+    assertThat((unwrapped as ApiResponse.Failure.Exception).throwable, `is`(throwable))
+  }
+
+  @Test
+  fun `unwrap with a spec works without modifying the response model`() {
+    val ok: ApiResponse<LegacyResponse> = ApiResponse.Success(LegacyResponse("OK", "payload", ""))
+    val failed: ApiResponse<LegacyResponse> =
+      ApiResponse.Success(LegacyResponse("NG", "", "quota exceeded"))
+
+    assertThat(ok.unwrap(LegacyResponseSpec).getOrNull(), `is`("payload"))
+    assertThat(failed.unwrap(LegacyResponseSpec) is ApiResponse.Failure.Error, `is`(true))
+    assertThat(failed.unwrap(LegacyResponseSpec).messageOrNull, `is`("quota exceeded"))
+  }
+
+  @Test
+  fun `global envelope mapper demotes a business failure without an explicit unwrap`() {
+    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
+
+    // The transport succeeded with HTTP 200, but the body encodes a business failure.
+    val response = ApiResponse.of { BaseResponse(code = -1, msg = "fail", data = null) }
+
+    assertThat(response is ApiResponse.Failure.Error, `is`(true))
+    assertThat((response as ApiResponse.Failure.Error).payload, `is`("fail"))
+  }
+
+  @Test
+  fun `global envelope mapper leaves a business success as Success`() {
+    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
+
+    val response = ApiResponse.of { BaseResponse(code = 0, msg = "success", data = "poster") }
+
+    assertThat(response is ApiResponse.Success, `is`(true))
+    assertThat(response.getOrNull()?.data, `is`("poster"))
+  }
+
+  @Test
+  fun `a demoted envelope failure still flows through global failure mappers`() {
+    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
+    SandwichInitializer.sandwichFailureMappers += ApiResponseFailureMapper { failure ->
+      val payload = (failure as ApiResponse.Failure.Error).payload
+      ApiResponse.Failure.Error(payload = "mapped: $payload")
+    }
+
+    val response = ApiResponse.of { BaseResponse(code = 10000, msg = "limited", data = null) }
+
+    assertThat(response is ApiResponse.Failure.Error, `is`(true))
+    assertThat((response as ApiResponse.Failure.Error).payload, `is`("mapped: limited"))
+  }
+
+  @Test
+  fun `global envelope mapper applies on the suspending creation path`() = runTest {
+    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
+
+    val response = ApiResponse.suspendOf { BaseResponse(code = -1, msg = "fail", data = null) }
+
+    assertThat(response is ApiResponse.Failure.Error, `is`(true))
+    assertThat((response as ApiResponse.Failure.Error).payload, `is`("fail"))
+  }
+
+  @Test
+  fun `no registered success mapper leaves the pipeline untouched`() {
+    val response = ApiResponse.of { BaseResponse(code = -1, msg = "fail", data = null) }
+
+    assertThat(response is ApiResponse.Success, `is`(true))
+    assertThat(response.getOrNull()?.code, `is`(-1))
+  }
+
+  @Test
+  fun `an envelope can classify a 200 response that carries a non-json error body`() {
+    val html: ApiResponse<SpreadSheetResponse> =
+      ApiResponse.Success(SpreadSheetResponse("<!DOCTYPE html><html>500</html>"))
+
+    val unwrapped = html.unwrap()
+
+    assertThat(unwrapped is ApiResponse.Failure.Error, `is`(true))
+    assertTrue((unwrapped as ApiResponse.Failure.Error).message().contains("HTML error page"))
+  }
+}

--- a/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/ApiEnvelopeTest.kt
+++ b/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/ApiEnvelopeTest.kt
@@ -66,7 +66,7 @@ internal class ApiEnvelopeTest {
   fun tearDown() {
     // NOTE: global state leaks between tests today — this is finding C3
     // (sandwich-test needs a reset rule).
-    SandwichInitializer.sandwichSuccessMappers = mutableListOf()
+    SandwichInitializer.sandwichSuccessMappers = mutableListOf(ApiEnvelopeMapper)
     SandwichInitializer.sandwichFailureMappers = mutableListOf()
   }
 
@@ -123,9 +123,7 @@ internal class ApiEnvelopeTest {
   }
 
   @Test
-  fun `global envelope mapper demotes a business failure without an explicit unwrap`() {
-    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
-
+  fun `the default envelope mapper demotes a business failure without an explicit unwrap`() {
     // The transport succeeded with HTTP 200, but the body encodes a business failure.
     val response = ApiResponse.of { BaseResponse(code = -1, msg = "fail", data = null) }
 
@@ -134,9 +132,7 @@ internal class ApiEnvelopeTest {
   }
 
   @Test
-  fun `global envelope mapper leaves a business success as Success`() {
-    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
-
+  fun `the default envelope mapper leaves a business success as Success`() {
     val response = ApiResponse.of { BaseResponse(code = 0, msg = "success", data = "poster") }
 
     assertThat(response is ApiResponse.Success, `is`(true))
@@ -145,7 +141,6 @@ internal class ApiEnvelopeTest {
 
   @Test
   fun `a demoted envelope failure still flows through global failure mappers`() {
-    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
     SandwichInitializer.sandwichFailureMappers += ApiResponseFailureMapper { failure ->
       val payload = (failure as ApiResponse.Failure.Error).payload
       ApiResponse.Failure.Error(payload = "mapped: $payload")
@@ -158,9 +153,7 @@ internal class ApiEnvelopeTest {
   }
 
   @Test
-  fun `global envelope mapper applies on the suspending creation path`() = runTest {
-    SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
-
+  fun `the default envelope mapper applies on the suspending creation path`() = runTest {
     val response = ApiResponse.suspendOf { BaseResponse(code = -1, msg = "fail", data = null) }
 
     assertThat(response is ApiResponse.Failure.Error, `is`(true))
@@ -168,11 +161,21 @@ internal class ApiEnvelopeTest {
   }
 
   @Test
-  fun `no registered success mapper leaves the pipeline untouched`() {
+  fun `removing the envelope mapper opts out of the automatic demotion`() {
+    SandwichInitializer.sandwichSuccessMappers -= ApiEnvelopeMapper
+
     val response = ApiResponse.of { BaseResponse(code = -1, msg = "fail", data = null) }
 
     assertThat(response is ApiResponse.Success, `is`(true))
     assertThat(response.getOrNull()?.code, `is`(-1))
+  }
+
+  @Test
+  fun `a body that does not implement ApiEnvelope passes through untouched`() {
+    val response = ApiResponse.of { LegacyResponse("NG", "", "quota exceeded") }
+
+    assertThat(response is ApiResponse.Success, `is`(true))
+    assertThat(response.getOrNull()?.reason, `is`("quota exceeded"))
   }
 
   @Test

--- a/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/GlobalPipelineReentrancyTest.kt
+++ b/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/GlobalPipelineReentrancyTest.kt
@@ -18,11 +18,15 @@ package com.skydoves.sandwich
 import com.skydoves.sandwich.envelope.ApiEnvelopeMapper
 import com.skydoves.sandwich.mappers.ApiResponseFailureMapper
 import com.skydoves.sandwich.operators.ApiResponseOperator
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.Is.`is`
 import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -144,5 +148,30 @@ internal class GlobalPipelineReentrancyTest {
     val response = ApiResponse.Success("poster", tag = "myTag").mapSuccess { length }
 
     assertThat(response.tagOrNull(), `is`("myTag"))
+  }
+
+  @Test
+  fun `mapSuccess re-throws a CancellationException instead of capturing it`() {
+    val cancellation = CancellationException("cancelled")
+
+    val thrown = assertThrows(CancellationException::class.java) {
+      ApiResponse.Success("poster").mapSuccess<String, Int> { throw cancellation }
+    }
+
+    assertThat(thrown, `is`(cancellation))
+  }
+
+  @Test
+  fun `a CancellationException from mapSuccess cancels the enclosing coroutine`() = runTest {
+    val job = launch {
+      ApiResponse.Success("poster").mapSuccess<String, Int> {
+        throw CancellationException("cancelled")
+      }
+      fail("mapSuccess captured the CancellationException instead of re-throwing it")
+    }
+
+    job.join()
+
+    assertThat(job.isCancelled, `is`(true))
   }
 }

--- a/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/GlobalPipelineReentrancyTest.kt
+++ b/sandwich-retrofit/src/test/kotlin/com/skydoves/sandwich/GlobalPipelineReentrancyTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich
+
+import com.skydoves.sandwich.envelope.ApiEnvelopeMapper
+import com.skydoves.sandwich.mappers.ApiResponseFailureMapper
+import com.skydoves.sandwich.operators.ApiResponseOperator
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.Is.`is`
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Regression tests for finding A16: transformers used to re-enter the global operator and mapper
+ * pipeline, because they created their result through [ApiResponse.of] and [ApiResponse.exception].
+ *
+ * A global operator must observe a response exactly once per request, no matter how long the
+ * transformation chain that follows is.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+internal class GlobalPipelineReentrancyTest {
+
+  private class CountingOperator<T> : ApiResponseOperator<T>() {
+    var successCount: Int = 0
+    var errorCount: Int = 0
+    var exceptionCount: Int = 0
+
+    override fun onSuccess(apiResponse: ApiResponse.Success<T>) {
+      successCount++
+    }
+
+    override fun onError(apiResponse: ApiResponse.Failure.Error) {
+      errorCount++
+    }
+
+    override fun onException(apiResponse: ApiResponse.Failure.Exception) {
+      exceptionCount++
+    }
+  }
+
+  @After
+  fun tearDown() {
+    SandwichInitializer.sandwichOperators = mutableListOf()
+    SandwichInitializer.sandwichSuccessMappers = mutableListOf(ApiEnvelopeMapper)
+    SandwichInitializer.sandwichFailureMappers = mutableListOf()
+  }
+
+  @Test
+  fun `a global operator observes a success exactly once across a mapSuccess chain`() {
+    val operator = CountingOperator<Any>()
+    SandwichInitializer.sandwichOperators += operator
+
+    ApiResponse.of { "poster" }
+      .mapSuccess { length }
+      .mapSuccess { this * 2 }
+      .mapSuccess { toString() }
+
+    assertThat(operator.successCount, `is`(1))
+  }
+
+  @Test
+  fun `a global operator observes a success exactly once across a suspendMapSuccess chain`() =
+    runTest {
+      val operator = CountingOperator<Any>()
+      SandwichInitializer.sandwichOperators += operator
+
+      ApiResponse.suspendOf { "poster" }
+        .suspendMapSuccess { length }
+        .suspendMapSuccess { this * 2 }
+
+      assertThat(operator.successCount, `is`(1))
+    }
+
+  @Test
+  fun `a global operator observes an exception exactly once across a mapFailure chain`() {
+    val operator = CountingOperator<Any>()
+    SandwichInitializer.sandwichOperators += operator
+
+    ApiResponse.exception(RuntimeException("boom"))
+      .mapFailure { RuntimeException("wrapped") }
+      .mapFailure { RuntimeException("wrapped twice") }
+
+    assertThat(operator.exceptionCount, `is`(1))
+  }
+
+  @Test
+  fun `merge does not report its intermediate accumulator to a global operator`() {
+    val operator = CountingOperator<Any>()
+    SandwichInitializer.sandwichOperators += operator
+
+    val first = ApiResponse.Success(listOf("a"))
+    val second = ApiResponse.Success(listOf("b"))
+
+    val merged = first.merge(second)
+
+    assertThat(merged.getOrNull(), `is`(listOf("a", "b")))
+    assertThat(operator.successCount, `is`(0))
+  }
+
+  @Test
+  fun `a global failure mapper is applied exactly once across a mapFailure chain`() {
+    SandwichInitializer.sandwichFailureMappers += ApiResponseFailureMapper { failure ->
+      ApiResponse.Failure.Exception(
+        RuntimeException("mapped:" + (failure as ApiResponse.Failure.Exception).message),
+      )
+    }
+
+    val response = ApiResponse.exception(RuntimeException("boom"))
+      .mapFailure { this }
+
+    val message = (response as ApiResponse.Failure.Exception).message
+    assertThat(message, `is`("mapped:boom"))
+  }
+
+  @Test
+  fun `mapSuccess still converts a throwing transformer into a failure`() {
+    val response = ApiResponse.Success("poster")
+      .mapSuccess<String, Int> { error("transformer failed") }
+
+    assertThat(response is ApiResponse.Failure.Exception, `is`(true))
+    assertThat((response as ApiResponse.Failure.Exception).message, `is`("transformer failed"))
+  }
+
+  @Test
+  fun `mapSuccess preserves the tag`() {
+    val response = ApiResponse.Success("poster", tag = "myTag").mapSuccess { length }
+
+    assertThat(response.tagOrNull(), `is`("myTag"))
+  }
+}

--- a/sandwich/api/android/sandwich.api
+++ b/sandwich/api/android/sandwich.api
@@ -248,10 +248,6 @@ public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapper : com/skydov
 	public fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Lcom/skydoves/sandwich/ApiResponse;
 }
 
-public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapperKt {
-	public static final fun enableEnvelopeSupport (Lcom/skydoves/sandwich/SandwichInitializer;)V
-}
-
 public abstract interface class com/skydoves/sandwich/envelope/ApiEnvelopeSpec {
 	public abstract fun envelopeBody (Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun envelopeError (Ljava/lang/Object;)Ljava/lang/Object;

--- a/sandwich/api/android/sandwich.api
+++ b/sandwich/api/android/sandwich.api
@@ -6,9 +6,11 @@ public final class com/skydoves/sandwich/ApiResponse$Companion {
 	public final fun exception (Ljava/lang/Throwable;)Lcom/skydoves/sandwich/ApiResponse$Failure$Exception;
 	public final fun maps (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
 	public final fun operate (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
+	public final fun successMaps (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
 	public final fun suspendException (Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendMaps (Lcom/skydoves/sandwich/ApiResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendOperate (Lcom/skydoves/sandwich/ApiResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendSuccessMaps (Lcom/skydoves/sandwich/ApiResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/skydoves/sandwich/ApiResponse$Failure : com/skydoves/sandwich/ApiResponse {
@@ -150,11 +152,13 @@ public final class com/skydoves/sandwich/SandwichInitializer {
 	public static final fun getSandwichFailureMappers ()Ljava/util/List;
 	public static final fun getSandwichOperators ()Ljava/util/List;
 	public final fun getSandwichScope ()Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getSandwichSuccessMappers ()Ljava/util/List;
 	public static final fun getSandwichTimeout ()Ljava/lang/Long;
 	public static final fun getSuccessCodeRange ()Lkotlin/ranges/IntRange;
 	public static final fun setSandwichFailureMappers (Ljava/util/List;)V
 	public static final fun setSandwichOperators (Ljava/util/List;)V
 	public final fun setSandwichScope (Lkotlinx/coroutines/CoroutineScope;)V
+	public static final fun setSandwichSuccessMappers (Ljava/util/List;)V
 	public static final fun setSandwichTimeout (Ljava/lang/Long;)V
 	public static final fun setSuccessCodeRange (Lkotlin/ranges/IntRange;)V
 }
@@ -233,6 +237,34 @@ public abstract interface annotation class com/skydoves/sandwich/SuspensionFunct
 public abstract interface annotation class com/skydoves/sandwich/annotations/InternalSandwichApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface class com/skydoves/sandwich/envelope/ApiEnvelope {
+	public abstract fun getEnvelopeBody ()Ljava/lang/Object;
+	public abstract fun getEnvelopeError ()Ljava/lang/Object;
+	public abstract fun isEnvelopeSuccessful ()Z
+}
+
+public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapper : com/skydoves/sandwich/mappers/ApiResponseSuccessMapper {
+	public static final field INSTANCE Lcom/skydoves/sandwich/envelope/ApiEnvelopeMapper;
+	public fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Lcom/skydoves/sandwich/ApiResponse;
+}
+
+public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapperKt {
+	public static final fun enableEnvelopeSupport (Lcom/skydoves/sandwich/SandwichInitializer;)V
+}
+
+public abstract interface class com/skydoves/sandwich/envelope/ApiEnvelopeSpec {
+	public abstract fun envelopeBody (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun envelopeError (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun isEnvelopeSuccessful (Ljava/lang/Object;)Z
+}
+
+public final class com/skydoves/sandwich/envelope/EnvelopeTransformer {
+	public static final synthetic fun toApiResponse (Lcom/skydoves/sandwich/envelope/ApiEnvelope;Ljava/lang/Object;)Lcom/skydoves/sandwich/ApiResponse;
+	public static synthetic fun toApiResponse$default (Lcom/skydoves/sandwich/envelope/ApiEnvelope;Ljava/lang/Object;ILjava/lang/Object;)Lcom/skydoves/sandwich/ApiResponse;
+	public static final synthetic fun unwrap (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
+	public static final synthetic fun unwrap (Lcom/skydoves/sandwich/ApiResponse;Lcom/skydoves/sandwich/envelope/ApiEnvelopeSpec;)Lcom/skydoves/sandwich/ApiResponse;
+}
+
 public final class com/skydoves/sandwich/exceptions/NoContentException : java/lang/Throwable {
 	public fun <init> (ILjava/lang/String;)V
 	public synthetic fun <init> (ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -256,11 +288,22 @@ public abstract interface class com/skydoves/sandwich/mappers/ApiResponseMapper 
 	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
 }
 
+public abstract interface class com/skydoves/sandwich/mappers/ApiResponseSuccessMapper : com/skydoves/sandwich/mappers/SandwichSuccessMapper {
+	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Lcom/skydoves/sandwich/ApiResponse;
+}
+
+public abstract interface class com/skydoves/sandwich/mappers/ApiResponseSuccessSuspendMapper : com/skydoves/sandwich/mappers/SandwichSuccessMapper {
+	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse$Success;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/skydoves/sandwich/mappers/ApiSuccessModelMapper {
 	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Ljava/lang/Object;
 }
 
 public abstract interface class com/skydoves/sandwich/mappers/SandwichFailureMapper {
+}
+
+public abstract interface class com/skydoves/sandwich/mappers/SandwichSuccessMapper {
 }
 
 public abstract class com/skydoves/sandwich/operators/ApiResponseOperator : com/skydoves/sandwich/operators/SandwichOperator {

--- a/sandwich/api/jvm/sandwich.api
+++ b/sandwich/api/jvm/sandwich.api
@@ -248,10 +248,6 @@ public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapper : com/skydov
 	public fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Lcom/skydoves/sandwich/ApiResponse;
 }
 
-public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapperKt {
-	public static final fun enableEnvelopeSupport (Lcom/skydoves/sandwich/SandwichInitializer;)V
-}
-
 public abstract interface class com/skydoves/sandwich/envelope/ApiEnvelopeSpec {
 	public abstract fun envelopeBody (Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun envelopeError (Ljava/lang/Object;)Ljava/lang/Object;

--- a/sandwich/api/jvm/sandwich.api
+++ b/sandwich/api/jvm/sandwich.api
@@ -6,9 +6,11 @@ public final class com/skydoves/sandwich/ApiResponse$Companion {
 	public final fun exception (Ljava/lang/Throwable;)Lcom/skydoves/sandwich/ApiResponse$Failure$Exception;
 	public final fun maps (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
 	public final fun operate (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
+	public final fun successMaps (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
 	public final fun suspendException (Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendMaps (Lcom/skydoves/sandwich/ApiResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendOperate (Lcom/skydoves/sandwich/ApiResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendSuccessMaps (Lcom/skydoves/sandwich/ApiResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/skydoves/sandwich/ApiResponse$Failure : com/skydoves/sandwich/ApiResponse {
@@ -150,11 +152,13 @@ public final class com/skydoves/sandwich/SandwichInitializer {
 	public static final fun getSandwichFailureMappers ()Ljava/util/List;
 	public static final fun getSandwichOperators ()Ljava/util/List;
 	public final fun getSandwichScope ()Lkotlinx/coroutines/CoroutineScope;
+	public static final fun getSandwichSuccessMappers ()Ljava/util/List;
 	public static final fun getSandwichTimeout ()Ljava/lang/Long;
 	public static final fun getSuccessCodeRange ()Lkotlin/ranges/IntRange;
 	public static final fun setSandwichFailureMappers (Ljava/util/List;)V
 	public static final fun setSandwichOperators (Ljava/util/List;)V
 	public final fun setSandwichScope (Lkotlinx/coroutines/CoroutineScope;)V
+	public static final fun setSandwichSuccessMappers (Ljava/util/List;)V
 	public static final fun setSandwichTimeout (Ljava/lang/Long;)V
 	public static final fun setSuccessCodeRange (Lkotlin/ranges/IntRange;)V
 }
@@ -233,6 +237,34 @@ public abstract interface annotation class com/skydoves/sandwich/SuspensionFunct
 public abstract interface annotation class com/skydoves/sandwich/annotations/InternalSandwichApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface class com/skydoves/sandwich/envelope/ApiEnvelope {
+	public abstract fun getEnvelopeBody ()Ljava/lang/Object;
+	public abstract fun getEnvelopeError ()Ljava/lang/Object;
+	public abstract fun isEnvelopeSuccessful ()Z
+}
+
+public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapper : com/skydoves/sandwich/mappers/ApiResponseSuccessMapper {
+	public static final field INSTANCE Lcom/skydoves/sandwich/envelope/ApiEnvelopeMapper;
+	public fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Lcom/skydoves/sandwich/ApiResponse;
+}
+
+public final class com/skydoves/sandwich/envelope/ApiEnvelopeMapperKt {
+	public static final fun enableEnvelopeSupport (Lcom/skydoves/sandwich/SandwichInitializer;)V
+}
+
+public abstract interface class com/skydoves/sandwich/envelope/ApiEnvelopeSpec {
+	public abstract fun envelopeBody (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun envelopeError (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun isEnvelopeSuccessful (Ljava/lang/Object;)Z
+}
+
+public final class com/skydoves/sandwich/envelope/EnvelopeTransformer {
+	public static final synthetic fun toApiResponse (Lcom/skydoves/sandwich/envelope/ApiEnvelope;Ljava/lang/Object;)Lcom/skydoves/sandwich/ApiResponse;
+	public static synthetic fun toApiResponse$default (Lcom/skydoves/sandwich/envelope/ApiEnvelope;Ljava/lang/Object;ILjava/lang/Object;)Lcom/skydoves/sandwich/ApiResponse;
+	public static final synthetic fun unwrap (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
+	public static final synthetic fun unwrap (Lcom/skydoves/sandwich/ApiResponse;Lcom/skydoves/sandwich/envelope/ApiEnvelopeSpec;)Lcom/skydoves/sandwich/ApiResponse;
+}
+
 public final class com/skydoves/sandwich/exceptions/NoContentException : java/lang/Throwable {
 	public fun <init> (ILjava/lang/String;)V
 	public synthetic fun <init> (ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -256,11 +288,22 @@ public abstract interface class com/skydoves/sandwich/mappers/ApiResponseMapper 
 	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse;)Lcom/skydoves/sandwich/ApiResponse;
 }
 
+public abstract interface class com/skydoves/sandwich/mappers/ApiResponseSuccessMapper : com/skydoves/sandwich/mappers/SandwichSuccessMapper {
+	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Lcom/skydoves/sandwich/ApiResponse;
+}
+
+public abstract interface class com/skydoves/sandwich/mappers/ApiResponseSuccessSuspendMapper : com/skydoves/sandwich/mappers/SandwichSuccessMapper {
+	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse$Success;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class com/skydoves/sandwich/mappers/ApiSuccessModelMapper {
 	public abstract fun map (Lcom/skydoves/sandwich/ApiResponse$Success;)Ljava/lang/Object;
 }
 
 public abstract interface class com/skydoves/sandwich/mappers/SandwichFailureMapper {
+}
+
+public abstract interface class com/skydoves/sandwich/mappers/SandwichSuccessMapper {
 }
 
 public abstract class com/skydoves/sandwich/operators/ApiResponseOperator : com/skydoves/sandwich/operators/SandwichOperator {

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ApiResponse.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ApiResponse.kt
@@ -20,6 +20,8 @@ package com.skydoves.sandwich
 import com.skydoves.sandwich.annotations.InternalSandwichApi
 import com.skydoves.sandwich.mappers.ApiResponseFailureMapper
 import com.skydoves.sandwich.mappers.ApiResponseFailureSuspendMapper
+import com.skydoves.sandwich.mappers.ApiResponseSuccessMapper
+import com.skydoves.sandwich.mappers.ApiResponseSuccessSuspendMapper
 import com.skydoves.sandwich.operators.ApiResponseOperator
 import com.skydoves.sandwich.operators.ApiResponseSuspendOperator
 import kotlinx.coroutines.launch
@@ -199,7 +201,7 @@ public sealed interface ApiResponse<out T> {
     @Suppress("UNCHECKED_CAST")
     public fun <T> ApiResponse<T>.maps(): ApiResponse<T> {
       val mappers = SandwichInitializer.sandwichFailureMappers
-      var response: ApiResponse<T> = this
+      var response: ApiResponse<T> = successMaps()
       mappers.forEach { mapper ->
         if (response is Failure) {
           if (mapper is ApiResponseFailureMapper) {
@@ -225,6 +227,64 @@ public sealed interface ApiResponse<out T> {
      *
      * @return [ApiResponse] A target [ApiResponse].
      */
+
+    /**
+     * @author skydoves (Jaewoong Eum)
+     *
+     * Maps [ApiResponse.Success] using global [SandwichInitializer.sandwichSuccessMappers],
+     * which may demote a transport-level success into an [ApiResponse.Failure.Error].
+     *
+     * [com.skydoves.sandwich.mappers.ApiResponseSuccessSuspendMapper] is skipped here, because a
+     * suspending mapper cannot be awaited from a blocking creation path. Use [suspendOf] to have
+     * suspending success mappers applied.
+     *
+     * @return [ApiResponse] The mapped [ApiResponse].
+     */
+    @InternalSandwichApi
+    @Suppress("UNCHECKED_CAST")
+    public fun <T> ApiResponse<T>.successMaps(): ApiResponse<T> {
+      val mappers = SandwichInitializer.sandwichSuccessMappers
+      if (mappers.isEmpty()) return this
+      var response: ApiResponse<T> = this
+      mappers.forEach { mapper ->
+        val current = response
+        if (current is Success && mapper is ApiResponseSuccessMapper) {
+          response = mapper.map(current) as ApiResponse<T>
+        }
+      }
+      return response
+    }
+
+    /**
+     * @author skydoves (Jaewoong Eum)
+     *
+     * Maps [ApiResponse.Success] using global [SandwichInitializer.sandwichSuccessMappers],
+     * which may demote a transport-level success into an [ApiResponse.Failure.Error].
+     *
+     * This suspend version properly awaits
+     * [com.skydoves.sandwich.mappers.ApiResponseSuccessSuspendMapper] operations.
+     *
+     * @return [ApiResponse] The mapped [ApiResponse].
+     */
+    @InternalSandwichApi
+    @Suppress("UNCHECKED_CAST")
+    public suspend fun <T> ApiResponse<T>.suspendSuccessMaps(): ApiResponse<T> {
+      val mappers = SandwichInitializer.sandwichSuccessMappers
+      if (mappers.isEmpty()) return this
+      var response: ApiResponse<T> = this
+      mappers.forEach { mapper ->
+        val current = response
+        if (current is Success) {
+          if (mapper is ApiResponseSuccessMapper) {
+            response = mapper.map(current) as ApiResponse<T>
+          } else if (mapper is ApiResponseSuccessSuspendMapper) {
+            response = mapper.map(current) as ApiResponse<T>
+          }
+        }
+      }
+      return response
+    }
+
     @InternalSandwichApi
     @Suppress("UNCHECKED_CAST")
     public suspend fun <T> ApiResponse<T>.suspendOperate(): ApiResponse<T> = apply {
@@ -252,7 +312,7 @@ public sealed interface ApiResponse<out T> {
     @Suppress("UNCHECKED_CAST")
     public suspend fun <T> ApiResponse<T>.suspendMaps(): ApiResponse<T> {
       val mappers = SandwichInitializer.sandwichFailureMappers
-      var response: ApiResponse<T> = this
+      var response: ApiResponse<T> = suspendSuccessMaps()
       mappers.forEach { mapper ->
         if (response is Failure) {
           if (mapper is ApiResponseFailureMapper) {

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ResponseTransformer.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ResponseTransformer.kt
@@ -476,7 +476,11 @@ public inline fun <reified T, reified V> ApiResponse<T>.mapSuccess(
 ): ApiResponse<V> {
   contract { callsInPlace(transformer, InvocationKind.AT_MOST_ONCE) }
   if (this is ApiResponse.Success<T>) {
-    return ApiResponse.of(tag = tag) { transformer(data) }
+    return try {
+      ApiResponse.Success(data = transformer(data), tag = tag)
+    } catch (e: Exception) {
+      ApiResponse.Failure.Exception(e)
+    }
   }
   return this as ApiResponse<V>
 }
@@ -497,8 +501,7 @@ public suspend inline fun <reified T, reified V> ApiResponse<T>.suspendMapSucces
   crossinline transformer: suspend T.() -> V,
 ): ApiResponse<V> {
   if (this is ApiResponse.Success<T>) {
-    val invoke = transformer(data)
-    return ApiResponse.of(tag = tag) { invoke }
+    return ApiResponse.Success(data = transformer(data), tag = tag)
   }
   return this as ApiResponse<V>
 }
@@ -517,7 +520,9 @@ public fun <T> ApiResponse<T>.mapFailure(transformer: Any?.() -> Any?): ApiRespo
   if (this is ApiResponse.Failure.Error) {
     return ApiResponse.Failure.Error(payload = transformer.invoke(payload))
   } else if (this is ApiResponse.Failure.Exception) {
-    return ApiResponse.exception(ex = (transformer.invoke(throwable) as? Throwable) ?: throwable)
+    return ApiResponse.Failure.Exception(
+      throwable = (transformer.invoke(throwable) as? Throwable) ?: throwable,
+    )
   }
   return this
 }
@@ -540,9 +545,8 @@ public suspend fun <T> ApiResponse<T>.suspendMapFailure(
   if (this is ApiResponse.Failure.Error) {
     return ApiResponse.Failure.Error(payload = transformer.invoke(payload))
   } else if (this is ApiResponse.Failure.Exception) {
-    return ApiResponse.suspendException(
-      ex =
-      (transformer.invoke(throwable) as? Throwable) ?: throwable,
+    return ApiResponse.Failure.Exception(
+      throwable = (transformer.invoke(throwable) as? Throwable) ?: throwable,
     )
   }
   return this
@@ -805,7 +809,8 @@ public fun <T> ApiResponse<List<T>>.merge(
   val apiResponses = responses.toMutableList()
   apiResponses.add(0, this)
 
-  var apiResponse: ApiResponse<List<T>> = ApiResponse.of(tag = tagOrNull()) { mutableListOf() }
+  var apiResponse: ApiResponse<List<T>> =
+    ApiResponse.Success(data = mutableListOf(), tag = tagOrNull())
 
   val data: MutableList<T> = mutableListOf()
 

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ResponseTransformer.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/ResponseTransformer.kt
@@ -466,11 +466,17 @@ public inline fun <reified T, reified V> ApiResponse<T>.flatmap(
  *
  * Maps a [T] type of the [ApiResponse] to a [V] type of the [ApiResponse] if the [ApiResponse] is [ApiResponse.Success].
  *
+ * If the [transformer] throws, the failure is captured as an [ApiResponse.Failure.Exception].
+ *
+ * Note: A [CancellationException] thrown by the [transformer] is re-thrown instead of being
+ * captured, to preserve coroutine cancellation semantics.
+ *
  * @param transformer A transformer that receives [T] and returns [V].
  *
  * @return A [V] type of the [ApiResponse].
  */
 @Suppress("UNCHECKED_CAST")
+@Throws(CancellationException::class)
 public inline fun <reified T, reified V> ApiResponse<T>.mapSuccess(
   crossinline transformer: T.() -> V,
 ): ApiResponse<V> {
@@ -478,6 +484,8 @@ public inline fun <reified T, reified V> ApiResponse<T>.mapSuccess(
   if (this is ApiResponse.Success<T>) {
     return try {
       ApiResponse.Success(data = transformer(data), tag = tag)
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       ApiResponse.Failure.Exception(e)
     }

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/SandwichInitializer.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/SandwichInitializer.kt
@@ -16,6 +16,7 @@
 package com.skydoves.sandwich
 
 import com.skydoves.sandwich.mappers.SandwichFailureMapper
+import com.skydoves.sandwich.mappers.SandwichSuccessMapper
 import com.skydoves.sandwich.operators.SandwichOperator
 import com.skydoves.sandwich.platform.platformCoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -73,6 +74,24 @@ public object SandwichInitializer {
    */
   @JvmStatic
   public var sandwichFailureMappers: MutableList<SandwichFailureMapper> = mutableListOf()
+
+  /**
+   * @author skydoves (Jaewoong Eum)
+   *
+   * A list of global success mappers that is executed by [ApiResponse]s globally on each response.
+   *
+   * [com.skydoves.sandwich.mappers.ApiResponseSuccessMapper] allows you to map the successful
+   * responses, including demoting them to [ApiResponse.Failure.Error]. This is the hook that
+   * powers the envelope (`BaseResponse`) pattern, where a server answers HTTP 200 while the body
+   * encodes a business failure.
+   * [com.skydoves.sandwich.mappers.ApiResponseSuccessSuspendMapper] can be used for suspension
+   * scope, and it is only applied on suspending creation paths such as [ApiResponse.suspendOf].
+   *
+   * By setting [sandwichSuccessMappers], Sandwich will automatically map all [ApiResponse] by
+   * using the [ApiResponse.of] function.
+   */
+  @JvmStatic
+  public var sandwichSuccessMappers: MutableList<SandwichSuccessMapper> = mutableListOf()
 
   /**
    * @author skydoves (Jaewoong Eum)

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/SandwichInitializer.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/SandwichInitializer.kt
@@ -15,6 +15,7 @@
  */
 package com.skydoves.sandwich
 
+import com.skydoves.sandwich.envelope.ApiEnvelopeMapper
 import com.skydoves.sandwich.mappers.SandwichFailureMapper
 import com.skydoves.sandwich.mappers.SandwichSuccessMapper
 import com.skydoves.sandwich.operators.SandwichOperator
@@ -89,9 +90,19 @@ public object SandwichInitializer {
    *
    * By setting [sandwichSuccessMappers], Sandwich will automatically map all [ApiResponse] by
    * using the [ApiResponse.of] function.
+   *
+   * [com.skydoves.sandwich.envelope.ApiEnvelopeMapper] is registered by default, so a response
+   * body implementing [com.skydoves.sandwich.envelope.ApiEnvelope] is classified by its business
+   * outcome out of the box. It only affects models that opt in by implementing the interface.
+   * Remove it from this list to opt out:
+   *
+   * ```kotlin
+   * SandwichInitializer.sandwichSuccessMappers -= ApiEnvelopeMapper
+   * ```
    */
   @JvmStatic
-  public var sandwichSuccessMappers: MutableList<SandwichSuccessMapper> = mutableListOf()
+  public var sandwichSuccessMappers: MutableList<SandwichSuccessMapper> =
+    mutableListOf(ApiEnvelopeMapper)
 
   /**
    * @author skydoves (Jaewoong Eum)

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelope.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelope.kt
@@ -1,0 +1,80 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich.envelope
+
+import com.skydoves.sandwich.ApiResponse
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * A contract for a response body that wraps the actual business payload, commonly known as
+ * an envelope (or `BaseResponse`) pattern.
+ *
+ * Many backends answer with HTTP 200 regardless of the business outcome and encode the real
+ * result inside the body:
+ *
+ * ```json
+ * { "code": 0, "message": "ok", "data": { ... } }
+ * ```
+ *
+ * Sandwich treats such a response as [ApiResponse.Success] because the transport layer did
+ * succeed. Implementing [ApiEnvelope] lets Sandwich additionally understand the *business*
+ * outcome, so a business failure can be demoted to [ApiResponse.Failure.Error].
+ *
+ * ```kotlin
+ * data class BaseResponse<T>(
+ *   val code: Int,
+ *   val message: String,
+ *   val data: T?,
+ * ) : ApiEnvelope<T?, String> {
+ *   override val isEnvelopeSuccessful: Boolean get() = code == 0
+ *   override val envelopeBody: T? get() = data
+ *   override val envelopeError: String get() = message
+ * }
+ * ```
+ *
+ * Implementing this interface enables two capabilities:
+ *
+ * 1. [unwrap] to flatten `ApiResponse<BaseResponse<T>>` into `ApiResponse<T>`.
+ * 2. Automatic demotion of business failures when [ApiEnvelopeMapper] is registered on
+ *    [com.skydoves.sandwich.SandwichInitializer.sandwichSuccessMappers].
+ *
+ * If you cannot modify the response model, use [ApiEnvelopeSpec] instead.
+ *
+ * @param T The type of the business payload.
+ * @param E The type of the business error.
+ */
+public interface ApiEnvelope<out T, out E> {
+
+  /** Whether the envelope represents a successful business outcome. */
+  public val isEnvelopeSuccessful: Boolean
+
+  /**
+   * The business payload.
+   *
+   * This is only accessed when [isEnvelopeSuccessful] is `true`, so implementations may
+   * throw or return a placeholder for the failed case.
+   */
+  public val envelopeBody: T
+
+  /**
+   * The business error.
+   *
+   * This is only accessed when [isEnvelopeSuccessful] is `false`, so implementations may
+   * throw or return a placeholder for the successful case.
+   */
+  public val envelopeError: E
+}

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelopeMapper.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelopeMapper.kt
@@ -1,0 +1,61 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich.envelope
+
+import com.skydoves.sandwich.ApiResponse
+import com.skydoves.sandwich.SandwichInitializer
+import com.skydoves.sandwich.mappers.ApiResponseSuccessMapper
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * A global [ApiResponseSuccessMapper] that demotes a transport-level success into an
+ * [ApiResponse.Failure.Error] when the body is an [ApiEnvelope] reporting a business failure.
+ *
+ * Register it once so that every response carrying an envelope is classified consistently,
+ * including responses observed by global operators:
+ *
+ * ```kotlin
+ * SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
+ * ```
+ *
+ * This mapper deliberately does **not** flatten a successful envelope, because doing so would
+ * make the runtime payload disagree with the declared type. Use [unwrap] at the call site to
+ * flatten `ApiResponse<BaseResponse<T>>` into `ApiResponse<T>`.
+ */
+public object ApiEnvelopeMapper : ApiResponseSuccessMapper {
+
+  override fun map(apiResponse: ApiResponse.Success<*>): ApiResponse<*> {
+    val data = apiResponse.data
+    return if (data is ApiEnvelope<*, *> && !data.isEnvelopeSuccessful) {
+      ApiResponse.Failure.Error(payload = data.envelopeError)
+    } else {
+      apiResponse
+    }
+  }
+}
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * Registers [ApiEnvelopeMapper] on [SandwichInitializer.sandwichSuccessMappers] if it has not
+ * been registered yet.
+ */
+public fun SandwichInitializer.enableEnvelopeSupport() {
+  if (!sandwichSuccessMappers.contains(ApiEnvelopeMapper)) {
+    sandwichSuccessMappers += ApiEnvelopeMapper
+  }
+}

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelopeMapper.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelopeMapper.kt
@@ -25,11 +25,15 @@ import com.skydoves.sandwich.mappers.ApiResponseSuccessMapper
  * A global [ApiResponseSuccessMapper] that demotes a transport-level success into an
  * [ApiResponse.Failure.Error] when the body is an [ApiEnvelope] reporting a business failure.
  *
- * Register it once so that every response carrying an envelope is classified consistently,
- * including responses observed by global operators:
+ * This mapper is registered on [SandwichInitializer.sandwichSuccessMappers] by default, so every
+ * response carrying an envelope is classified consistently, including responses observed by
+ * global operators. A response body that does not implement [ApiEnvelope] passes through
+ * untouched, so the default registration is inert for models that do not opt in.
+ *
+ * Remove it to opt out:
  *
  * ```kotlin
- * SandwichInitializer.sandwichSuccessMappers += ApiEnvelopeMapper
+ * SandwichInitializer.sandwichSuccessMappers -= ApiEnvelopeMapper
  * ```
  *
  * This mapper deliberately does **not** flatten a successful envelope, because doing so would
@@ -45,17 +49,5 @@ public object ApiEnvelopeMapper : ApiResponseSuccessMapper {
     } else {
       apiResponse
     }
-  }
-}
-
-/**
- * @author skydoves (Jaewoong Eum)
- *
- * Registers [ApiEnvelopeMapper] on [SandwichInitializer.sandwichSuccessMappers] if it has not
- * been registered yet.
- */
-public fun SandwichInitializer.enableEnvelopeSupport() {
-  if (!sandwichSuccessMappers.contains(ApiEnvelopeMapper)) {
-    sandwichSuccessMappers += ApiEnvelopeMapper
   }
 }

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelopeSpec.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/ApiEnvelopeSpec.kt
@@ -1,0 +1,53 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich.envelope
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * A non-intrusive counterpart of [ApiEnvelope] that describes the envelope contract from the
+ * outside, so the response model does not need to be modified.
+ *
+ * This is useful when the model is generated (protobuf, OpenAPI, KSP) or owned by another module.
+ *
+ * ```kotlin
+ * data class BaseResponse<T>(val code: Int, val message: String, val data: T?)
+ *
+ * class BaseResponseSpec<T> : ApiEnvelopeSpec<BaseResponse<T>, T?, String> {
+ *   override fun isEnvelopeSuccessful(envelope: BaseResponse<T>): Boolean = envelope.code == 0
+ *   override fun envelopeBody(envelope: BaseResponse<T>): T? = envelope.data
+ *   override fun envelopeError(envelope: BaseResponse<T>): String = envelope.message
+ * }
+ *
+ * val response: ApiResponse<List<Poster>> =
+ *   service.fetchPosters().unwrap(BaseResponseSpec())
+ * ```
+ *
+ * @param ENV The envelope type.
+ * @param T The type of the business payload.
+ * @param E The type of the business error.
+ */
+public interface ApiEnvelopeSpec<in ENV, out T, out E> {
+
+  /** Whether the [envelope] represents a successful business outcome. */
+  public fun isEnvelopeSuccessful(envelope: ENV): Boolean
+
+  /** Extracts the business payload from the [envelope]. */
+  public fun envelopeBody(envelope: ENV): T
+
+  /** Extracts the business error from the [envelope]. */
+  public fun envelopeError(envelope: ENV): E
+}

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/EnvelopeTransformer.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/envelope/EnvelopeTransformer.kt
@@ -1,0 +1,94 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("unused", "RedundantVisibilityModifier")
+@file:JvmName("EnvelopeTransformer")
+@file:JvmMultifileClass
+
+package com.skydoves.sandwich.envelope
+
+import com.skydoves.sandwich.ApiResponse
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * Flattens an `ApiResponse<ENV>` that holds an [ApiEnvelope] into an `ApiResponse<T>` that holds
+ * the business payload.
+ *
+ * - If the response is [ApiResponse.Success] and the envelope reports a successful business
+ *   outcome, an [ApiResponse.Success] with [ApiEnvelope.envelopeBody] is returned.
+ * - If the response is [ApiResponse.Success] but the envelope reports a business failure, it is
+ *   demoted to an [ApiResponse.Failure.Error] carrying [ApiEnvelope.envelopeError] as the payload.
+ * - If the response is already an [ApiResponse.Failure], it is returned as is.
+ *
+ * ```kotlin
+ * // service declares the wire type
+ * suspend fun fetchPosters(): ApiResponse<BaseResponse<List<Poster>>>
+ *
+ * // repository exposes the business type
+ * suspend fun posters(): ApiResponse<List<Poster>?> = service.fetchPosters().unwrap()
+ * ```
+ *
+ * @return An [ApiResponse] holding the unwrapped business payload.
+ */
+@JvmSynthetic
+@Suppress("UNCHECKED_CAST")
+public fun <T> ApiResponse<ApiEnvelope<T, *>>.unwrap(): ApiResponse<T> = when (this) {
+  is ApiResponse.Success -> data.toApiResponse(tag)
+  is ApiResponse.Failure -> this as ApiResponse<T>
+}
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * Flattens an `ApiResponse<ENV>` into an `ApiResponse<T>` using an external [ApiEnvelopeSpec],
+ * so the response model does not need to implement [ApiEnvelope].
+ *
+ * @param spec A specification that describes how to interpret the envelope.
+ *
+ * @return An [ApiResponse] holding the unwrapped business payload.
+ */
+@JvmSynthetic
+@Suppress("UNCHECKED_CAST")
+public fun <ENV, T> ApiResponse<ENV>.unwrap(spec: ApiEnvelopeSpec<ENV, T, *>): ApiResponse<T> =
+  when (this) {
+    is ApiResponse.Success -> if (spec.isEnvelopeSuccessful(data)) {
+      ApiResponse.Success(data = spec.envelopeBody(data), tag = tag)
+    } else {
+      ApiResponse.Failure.Error(payload = spec.envelopeError(data))
+    }
+    is ApiResponse.Failure -> this as ApiResponse<T>
+  }
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * Converts this [ApiEnvelope] into an [ApiResponse] depending on its business outcome.
+ *
+ * @param tag An additional value that will be held by the resulting [ApiResponse.Success].
+ *
+ * @return [ApiResponse.Success] holding [ApiEnvelope.envelopeBody] if the envelope is successful,
+ * otherwise [ApiResponse.Failure.Error] holding [ApiEnvelope.envelopeError].
+ */
+@JvmSynthetic
+public fun <T> ApiEnvelope<T, *>.toApiResponse(tag: Any? = null): ApiResponse<T> =
+  if (isEnvelopeSuccessful) {
+    ApiResponse.Success(data = envelopeBody, tag = tag)
+  } else {
+    ApiResponse.Failure.Error(payload = envelopeError)
+  }

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/mappers/ApiResponseSuccessMapper.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/mappers/ApiResponseSuccessMapper.kt
@@ -1,0 +1,43 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich.mappers
+
+import com.skydoves.sandwich.ApiResponse
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * A mapper interface for mapping an [ApiResponse.Success] into another [ApiResponse].
+ *
+ * Unlike [ApiResponseFailureMapper], the returned type is a plain [ApiResponse], so an
+ * implementation may **demote** a transport-level success into an [ApiResponse.Failure.Error].
+ * This is the hook that powers the envelope (`BaseResponse`) pattern where the server answers
+ * HTTP 200 while the body encodes a business failure.
+ *
+ * The returned [ApiResponse] must keep the same runtime payload type, because the static type
+ * of the response cannot change. To also flatten the payload type, use
+ * [com.skydoves.sandwich.envelope.unwrap] at the call site.
+ */
+public fun interface ApiResponseSuccessMapper : SandwichSuccessMapper {
+
+  /**
+   * Maps an [ApiResponse.Success].
+   *
+   * @param apiResponse The [ApiResponse.Success] response from the network request.
+   * @return The same or a demoted [ApiResponse].
+   */
+  public fun map(apiResponse: ApiResponse.Success<*>): ApiResponse<*>
+}

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/mappers/ApiResponseSuccessSuspendMapper.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/mappers/ApiResponseSuccessSuspendMapper.kt
@@ -1,0 +1,39 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich.mappers
+
+import com.skydoves.sandwich.ApiResponse
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * A suspending mapper interface for mapping an [ApiResponse.Success] into another [ApiResponse].
+ *
+ * This mapper is only applied on suspending creation paths such as
+ * [com.skydoves.sandwich.ApiResponse.Companion.suspendOf], because a suspending mapper cannot be
+ * awaited from a blocking creation path. Use [ApiResponseSuccessMapper] if the mapping has to run
+ * for every creation path.
+ */
+public interface ApiResponseSuccessSuspendMapper : SandwichSuccessMapper {
+
+  /**
+   * Maps an [ApiResponse.Success].
+   *
+   * @param apiResponse The [ApiResponse.Success] response from the network request.
+   * @return The same or a demoted [ApiResponse].
+   */
+  public suspend fun map(apiResponse: ApiResponse.Success<*>): ApiResponse<*>
+}

--- a/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/mappers/SandwichSuccessMapper.kt
+++ b/sandwich/src/commonMain/kotlin/com/skydoves/sandwich/mappers/SandwichSuccessMapper.kt
@@ -1,0 +1,26 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.sandwich.mappers
+
+import com.skydoves.sandwich.ApiResponse
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * A marker interface of a success mapper which maps an [ApiResponse.Success] which should be
+ * handled globally.
+ */
+public interface SandwichSuccessMapper


### PR DESCRIPTION
## Summary

Adds support for envelope (`BaseResponse`) style responses, where a server answers HTTP 200 while the body encodes a business failure. Also fixes two bugs found while building it.

## Envelope support

A response model can declare its business outcome:

```kotlin
data class BaseResponse<T>(
  val code: Int,
  val message: String,
  val data: T?,
) : ApiEnvelope<T?, String> {
  override val isEnvelopeSuccessful: Boolean get() = code == 0
  override val envelopeBody: T? get() = data
  override val envelopeError: String get() = message
}
```

`ApiEnvelopeMapper` is registered on `SandwichInitializer.sandwichSuccessMappers` by default, so a business failure is classified as `ApiResponse.Failure.Error` with no setup. A body that does not implement `ApiEnvelope` passes through untouched, so the default registration is inert for existing models.

`unwrap()` flattens `ApiResponse<BaseResponse<T>>` into `ApiResponse<T>` at the repository boundary. `ApiEnvelopeSpec` covers models that cannot be modified.

New API:

- `ApiEnvelope<T, E>` and `ApiEnvelopeSpec<ENV, T, E>`
- `unwrap()`, `unwrap(spec)`, `toApiResponse()`
- `ApiResponseSuccessMapper`, `ApiResponseSuccessSuspendMapper`, `SandwichSuccessMapper`
- `SandwichInitializer.sandwichSuccessMappers`

Success mappers run before failure mappers, so a demoted response still flows through global failure mappers. Documented in `docs/envelope.md`.

Reported in #30, #38, #85 and #138.

## Fix: the global pipeline ran once per transformation

`mapSuccess`, `suspendMapSuccess`, `mapFailure`, `suspendMapFailure` and `merge` built their result through `ApiResponse.of` and `ApiResponse.exception`, which re-entered the global operator and mapper pipeline on every call.

Measured before the fix:

| Case | Expected | Actual |
| --- | --- | --- |
| Global operator over a 3 step `mapSuccess` chain | 1 | 4 |
| Global operator over a 2 step `suspendMapSuccess` chain | 1 | 3 |
| Global operator over a 2 step `mapFailure` chain | 1 | 3 |
| `merge` reporting its internal accumulator | 0 | 1 |
| Global failure mapper result | `mapped:boom` | `mapped:mapped:boom` |

A `TokenRefreshGlobalOperator` as documented in the README therefore re-ran its token check on every `mapSuccess`. These transformers now construct the result directly, keeping the exception wrapping and the `tag`.

## Fix: mapSuccess captured CancellationException

`mapSuccess` wrapped a throwing transformer with `catch (e: Exception)`, which also captured `CancellationException` and left the enclosing coroutine running. It now rethrows it first, matching `suspendOf` and the Retrofit and Ktor `apiResponseOf` factories.

`suspendMapSuccess` already invokes its transformer outside the try block, so it needs no change.

## Compatibility

The `.api` dump diff is 78 insertions and 0 deletions. No signature is removed or changed.

## Testing

- 223 tests pass, 21 of them new
- Both fixes have regression tests that fail when the fix is reverted
- Compiles on js, wasmJs and iosSimulatorArm64
- `spotlessCheck` and `apiCheck` pass

## Note

The last commit adds `tasks/` to `.gitignore` for local working notes. Drop it if it does not belong here.
