### PR TITLE
Prepare for release 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Add the dependency below into your **module**'s `build.gradle` file:
 
 ```gradle
 dependencies {
-    implementation("com.github.skydoves:sandwich:2.3.0")
-    implementation("com.github.skydoves:sandwich-retrofit:2.3.0") // For Retrofit (Android)
-    testImplementation("com.github.skydoves:sandwich-test:2.3.0") // For Testing
+    implementation(platform("com.github.skydoves:sandwich-bom:2.4.0"))
+
+    implementation("com.github.skydoves:sandwich")
+    implementation("com.github.skydoves:sandwich-retrofit") // For Retrofit (Android)
+    testImplementation("com.github.skydoves:sandwich-test") // For Testing
 }
 ```
 
@@ -40,14 +42,17 @@ For Kotlin Multiplatform, add the dependency below to your module's `build.gradl
 sourceSets {
     val commonMain by getting {
         dependencies {
-            implementation("com.github.skydoves:sandwich:$version")
-            implementation("com.github.skydoves:sandwich-ktor:$version")
-            implementation("com.github.skydoves:sandwich-ktorfit:$version")
+            implementation(project.dependencies.platform("com.github.skydoves:sandwich-bom:$version"))
+
+            implementation("com.github.skydoves:sandwich")
+            implementation("com.github.skydoves:sandwich-ktor")
+            implementation("com.github.skydoves:sandwich-ktor-serialization")
+            implementation("com.github.skydoves:sandwich-ktorfit")
         }
     }
     val commonTest by getting {
         dependencies {
-            implementation("com.github.skydoves:sandwich-test:$version")
+            implementation("com.github.skydoves:sandwich-test")
         }
     }
 }

--- a/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/sandwich/Configuration.kt
@@ -22,10 +22,10 @@ object Configuration {
   const val minSdk = 21
   const val minSdkDemo = 23
   const val majorVersion = 2
-  const val minorVersion = 3
+  const val minorVersion = 4
   const val patchVersion = 0
   const val versionName = "$majorVersion.$minorVersion.$patchVersion"
-  const val versionCode = 50
+  const val versionCode = 51
   const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
   const val artifactGroup = "com.github.skydoves"
 }

--- a/sandwich-ktor-serialization/gradle.properties
+++ b/sandwich-ktor-serialization/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=sandwich-ktor-serialization
+POM_NAME=sandwich-ktor-serialization
+POM_DESCRIPTION=A lightweight and pluggable sealed API library for modeling Retrofit responses and handling exceptions on Kotlin and Android.


### PR DESCRIPTION
Bumps the version to 2.4.0 and points the README at the BOM.

Also adds the POM metadata that `sandwich-ktor-serialization` was missing. Every other Kotlin Multiplatform module carries a `gradle.properties` with `POM_NAME` and `POM_DESCRIPTION`. Without it the generated POM had neither field, and Maven Central rejects a POM with no name or description, so publishing 2.4.0 would have failed on that artifact.

Verified locally: 415 tests pass, `assembleRelease` succeeds, and all nine publishable modules now generate a POM carrying both fields.